### PR TITLE
Add hpc/hmst-services

### DIFF
--- a/hpc/hmst-services/files/upstart.conf
+++ b/hpc/hmst-services/files/upstart.conf
@@ -1,0 +1,12 @@
+description "HMST Services Tier Webserver"
+author "niklas@fpcomplete.com"
+start on filesystem
+stop on runlevel [!2345]
+respawn
+setuid {{ run_as_user }}
+setgid {{ run_as_user }}
+chdir {{ cwd }}
+env HMST_SIMULATOR_REDIS_HOST={{ redis_host }}
+script
+  {{ bin_path }} Production --port {{ port }}
+end script

--- a/hpc/hmst-services/init.sls
+++ b/hpc/hmst-services/init.sls
@@ -1,0 +1,49 @@
+hmst-services:
+  file.managed:
+    - name: /etc/init/hmst-services.conf
+    - mode: 640
+    - user: root
+    - group: root
+    - source: salt://hpc/hmst-services/files/upstart.conf
+    - template: jinja
+    - defaults:
+        bin_path: /usr/local/bin/hmst-services
+        cwd: /usr/local/lib/hmst-services
+        run_as_user: 'ubuntu'
+        port: 8000
+        redis_host: 10.200.10.180
+  service.running:
+    - name: hmst-services
+    - watch:
+        - file: hmst-services
+        - file: hmst-services-executable
+        - file: hmst-services-config
+
+
+hmst-services-executable:
+  file.managed:
+    - name: /usr/local/bin/hmst-services
+    - mode: 755
+    - user: root
+    - group: root
+    - source: salt://hpc/hmst-services/files/services
+
+
+hmst-services-config:
+  file.recurse:
+    - name: /usr/local/lib/hmst-services/config
+    - dir_mode: 2755
+    - file_mode: 640
+    - user: ubuntu
+    - group: ubuntu
+    - source: salt://hpc/hmst-services/files/config/
+
+
+hmst-services-static:
+  file.recurse:
+    - name: /usr/local/lib/hmst-services/static
+    - dir_mode: 2755
+    - file_mode: 640
+    - user: ubuntu
+    - group: ubuntu
+    - source: salt://hpc/hmst-services/files/static/


### PR DESCRIPTION
Hi @ketzacoatl, here comes the PR for https://github.com/fpco/hmst/issues/38.

Some things to look at:
- Since the `ubuntu` user runs the executable, the `config` and `static` files are also owned by it.
- I have no `watch` for `- file: hmst-services-static` since the service doesn't have to be reloaded when static files change (it picks them up at runtime).
- Have I correctly included all changes you made since I made the `hmst-simulator` PR?
- We could also switch over to the Keter based archive deployment for config/static files that you mentioned.
