### PR TITLE
Fix bad eth0 assumption for vagrant

### DIFF
--- a/nomad/consul_check_agent.sls
+++ b/nomad/consul_check_agent.sls
@@ -6,7 +6,9 @@
 {%- set consul_conf = '/home/consul' %}
 {%- set user = 'consul' %}
 {%- set server = salt['pillar.get']('nomad:server', False) %}
-{%- set service_ip = salt['grains.get']('ip4_interfaces')['eth0'][0] %}
+{%- set default_netif = 'eth0' %}
+{%- set network_interface = salt['pillar.get']('nomad:net_if', default_netif) %}
+{%- set service_ip = salt['grains.get']('ip4_interfaces')[network_interface][0] %}
 {%- set http_port = 4646 %}
 {%- set rpc_port = 4647 %}
 

--- a/tests/srv/pillar/bootstrap.sls
+++ b/tests/srv/pillar/bootstrap.sls
@@ -7,3 +7,8 @@ reclass:
       - hashistack-single-node
     parameters:
       foo: bar
+
+nomad:
+  net_if: enp0s3
+vault:
+  net_if: enp0s3

--- a/vault/files/config.json
+++ b/vault/files/config.json
@@ -1,6 +1,8 @@
 {%- set home = '/var/lib/vault' %}
 {%- set default_file_backend = home ~ '/tmp' %}
-{%- set default_ip = salt['grains.get']('ip4_interfaces')['eth0'][0] %}
+{%- set default_netif = 'eth0' %}
+{%- set network_interface = salt['pillar.get']('vault:net_if', default_netif) %}
+{%- set default_ip = salt['grains.get']('ip4_interfaces')[network_interface][0] %}
 {%- set dc = salt['pillar.get']('vault:datacenter', False) %}
 {%- set http_port = salt['pillar.get']('vault:port', '8200') %}
 {%- set http_ip = salt['pillar.get']('vault:ip', default_ip) %}

--- a/vault/service.sls
+++ b/vault/service.sls
@@ -8,7 +8,9 @@
 {%- set config_args = ' -config ' ~ conf_file %}
 {%- set default_args = 'server' ~ config_args %}
 {%- set desc = 'Hashicorp Vault' %}
-{%- set default_ip = salt['grains.get']('ip4_interfaces')['eth0'][0] %}
+{%- set default_netif = 'eth0' %}
+{%- set network_interface = salt['pillar.get']('vault:net_if', default_netif) %}
+{%- set default_ip = salt['grains.get']('ip4_interfaces')[network_interface][0] %}
 {%- set http_ip = salt['pillar.get']('vault:ip', default_ip) %}
 {%- set http_port = salt['pillar.get']('vault:port', '8200') %}
 


### PR DESCRIPTION
https://github.com/fpco/fpco-salt-formula/issues/123#event-1737976534

The formulas NTP, Consul and Cog works without to have added a default `net_if`