### PR TITLE
Fix Vault deprecated command

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -111,8 +111,8 @@ Vagrant.configure("2") do |config|
     sudo consul members || true
     nomad server members || true
     nomad status || true
-    vault version || true
-    vault init || true
+    echo "$(vault version)" || true
+    vault operator init || true
     sleep 2
     vault status || true
     echo "DONE! ssh in and get hacking: vagrant ssh"


### PR DESCRIPTION
fix https://github.com/fpco/fpco-salt-formula/issues/148

```bash
    default: Name              Address    Port  Status  Leader  Protocol  Build  Datacenter  Region                                                           
    default: ubuntu-xenial.us  10.0.2.15  4648  alive   true    2         0.8.4  vagrant     us                                                               
    default: No running jobs                                                                                                                                  
    default: Vault v0.10.3 ('c69ae68faf2bf7fc1d78e3ec62655696a07454c7')                                                                                       
    default: Error initializing: Put https://127.0.0.1:8200/v1/sys/init                                                                                       
    default: : dial tcp 127.0.0.1:8200:                                                                                                                       
    default: connect: connection refused                                                                                                                      
    default: Error checking seal status: Get https://127.0.0.1:8200/v1/sys/seal-status: dial tcp 127.0.0.1:8200: connect: connection refused
    default: DONE! ssh in and get hacking: vagrant ssh  
```