### PR TITLE
nomad: Setup alias for nomad commands #95

### DIFF
--- a/nomad/install.sls
+++ b/nomad/install.sls
@@ -48,3 +48,20 @@ nomad-bin:
     - target: {{ bin_path }}-{{ version }}/{{ app }}
     - require:
         - file: nomad-archive
+
+nomad-alias-conf:
+  file.managed:
+    - name: /etc/profile.d/nomad-alias.sh
+    - user: root
+    - group: root
+    - mode: 755
+    - contents: |
+          #!/usr/bin/env bash
+
+          alias ns='nomad status'
+          alias nas='nomad alloc-status'
+          alias nns='nomad node-status'
+          alias nr='nomad run'
+          alias n='nomad stop'
+          alias nfc='nomad fs cat'
+          alias n='nomad fs ls'


### PR DESCRIPTION
Issue #95 

#### output
```
root@ubuntu-xenial:~# salt-call --local state.sls nomad.install
```
```
local:
----------
          ID: unzip
    Function: pkg.installed
      Result: True
     Comment: All specified packages are already installed
     Started: 20:44:40.260260
    Duration: 329.296 ms
     Changes:   
----------
          ID: nomad-user
    Function: group.present
        Name: nomad
      Result: True
     Comment: Group nomad is present and up to date
     Started: 20:44:40.590152
    Duration: 0.496 ms
     Changes:   
----------
          ID: nomad-user
    Function: user.present
        Name: nomad
      Result: True
     Comment: User nomad is present and up to date
     Started: 20:44:40.591661
    Duration: 1.398 ms
     Changes:   
----------
          ID: nomad-data-dir
    Function: file.directory
        Name: /var/lib/nomad/tmp
      Result: True
     Comment: The directory /var/lib/nomad/tmp is in the correct state
     Started: 20:44:40.595804
    Duration: 0.806 ms
     Changes:   
----------
          ID: nomad-user
    Function: file.directory
        Name: /var/lib/nomad
      Result: True
     Comment: The directory /var/lib/nomad is in the correct state
     Started: 20:44:40.596899
    Duration: 2.204 ms
     Changes:   
----------
          ID: nomad-archive
    Function: archive.extracted
        Name: /usr/local/bin/nomad-0.8.4
      Result: True
     Comment: Path /usr/local/bin/nomad-0.8.4/nomad exists
     Started: 20:44:40.600140
    Duration: 0.517 ms
     Changes:   
----------
          ID: nomad-archive
    Function: file.directory
        Name: /usr/local/bin/nomad-0.8.4
      Result: True
     Comment: The directory /usr/local/bin/nomad-0.8.4 is in the correct state
     Started: 20:44:40.601121
    Duration: 0.825 ms
     Changes:   
----------
          ID: nomad-bin
    Function: file.symlink
        Name: /usr/local/bin/nomad
      Result: True
     Comment: Symlink /usr/local/bin/nomad is present and owned by root:root
     Started: 20:44:40.602150
    Duration: 1.455 ms
     Changes:   
----------
          ID: nomad-alias-conf
    Function: file.managed
        Name: /etc/profile.d/nomad-alias.sh
      Result: True
     Comment: File /etc/profile.d/nomad-alias.sh updated
     Started: 20:44:40.603756
    Duration: 11.412 ms
     Changes:   
              ----------
              diff:
                  New file
              mode:
                  0755

Summary for local
------------
Succeeded: 9 (changed=1)
Failed:    0
------------
Total states run:     9
Total run time: 348.409 ms

```
```
root@ubuntu-xenial:~# ns 
No running jobs
root@ubuntu-xenial:~# alias
alias egrep='egrep --color=auto'
alias fgrep='fgrep --color=auto'
alias grep='grep --color=auto'
alias l='ls -CF'
alias la='ls -A'
alias ll='ls -alF'
alias ls='ls --color=auto'
alias n='nomad fs ls'
alias nas='nomad alloc-status'
alias nfc='nomad fs cat'
alias nns='nomad node-status'
alias nr='nomad run'
alias ns='nomad status'
```