### PR TITLE
Vault: ufw for vault

### DIFF
--- a/reclass/classes/vault.yml
+++ b/reclass/classes/vault.yml
@@ -1,5 +1,6 @@
 applications:
   - vault.service
+  - vault.ufw
 #classes:
 #  - foo
 parameters:

--- a/vault/ufw.sls
+++ b/vault/ufw.sls
@@ -1,0 +1,11 @@
+# configure ufw (firewall) policies for the vault server
+
+{%- from "hashicorp/macro.sls" import render_app_ufw_formula with context %}
+
+# description for the service unit and ufw configuration files
+{%- set desc = salt['pillar.get']('vault:systemd_desc', "Hashiscorp Vault Server") %}
+{%- set server_name = "vault" %}
+# list of ports for UFW, for the server and task allocations
+{%- set server_ufw_ports = salt['pillar.get']('vault:port',"8200") %}
+
+{{ render_app_ufw_formula(server_name, server_desc, server_ufw_ports) }}


### PR DESCRIPTION
Issue #160 

#### Requirements completed:
- Create an ufw profile for vault
- Allow port 8200 for vault server

#### Local testing
```bash
root@ubuntu-xenial:~# salt-call --local state.sls vault.ufw
```
```
local:
----------
          ID: vault-ufw-app-config
    Function: file.managed
        Name: /etc/ufw/applications.d/vault.ufw
      Result: True
     Comment: File /etc/ufw/applications.d/vault.ufw is in the correct state
     Started: 15:15:09.582888
    Duration: 67.972 ms
     Changes:   
----------
          ID: vault-ufw-app-config
    Function: cmd.run
        Name: ufw allow vault
      Result: True
     Comment: Command "ufw allow vault" run
     Started: 15:15:09.652595
    Duration: 111.158 ms
     Changes:   
              ----------
              pid:
                  7574
              retcode:
                  0
              stderr:
              stdout:
                  Rules updated
                  Rules updated (v6)

Summary for local
------------
Succeeded: 2 (changed=1)
Failed:    0
------------
Total states run:     2
Total run time: 179.130 ms
```