### PR TITLE
Fix vagrant env for nomad jobs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -113,4 +113,5 @@ Vagrant.configure("2") do |config|
   SHELL
 
   config.vm.provision "shell", path: "tests/scripts/test-hashistack.sh"
+  config.vm.provision "shell", path: "tests/scripts/test-nomad-job.sh"
 end

--- a/nomad/files/client-server-config.hcl
+++ b/nomad/files/client-server-config.hcl
@@ -97,11 +97,13 @@ server {
   bootstrap_expect = {{ bootstrap_expect }}
     {%- if num_schedulers %}"num_schedulers = "{{ num_schedulers }}"{% endif %}
     {%- if enabled_schedulers %}"enabled_schedulers = "{{ enabled_schedulers }}"{% endif %}
-  retry_join = [
-      {% for s in join_servers %}"{{ s }}",
-      {% endfor -%}
-  ]
-  retry_interval = "{{ retry_interval }}"
+  server_join {
+    retry_join = [
+        {% for s in join_servers %}"{{ s }}",
+        {% endfor -%}
+    ]
+    retry_interval = "{{ retry_interval }}"
+  }
 }
 {%- endif %}
 

--- a/tests/scripts/test-nomad-job.sh
+++ b/tests/scripts/test-nomad-job.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+
+# Fix error nomad can resolve nomad.service.consul domain
+ip=`ifconfig enp0s3 | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p'`
+grep $ip /etc/hosts || echo "$ip nomad.service.consul" >> /etc/hosts
+
+# Run nomad job
+echo "Init example job"
+nomad run /vagrant/tests/scripts/test-nomad.nomad
+echo "Wait 10s to nomad init the job"
+sleep 10
+
+# Check status of the job
+echo "Example job status"
+nomad status example
+
+# Test nomad job
+echo "Curl to check that nomad job is up"
+curl $ip:8080 || echo "Nomad Job Fail"

--- a/tests/scripts/test-nomad.nomad
+++ b/tests/scripts/test-nomad.nomad
@@ -1,0 +1,128 @@
+
+job "example" {
+  datacenters = ["vagrant"]
+  type = "service"
+
+  update {
+    max_parallel = 1
+    min_healthy_time = "10s"
+    healthy_deadline = "3m"
+    progress_deadline = "10m"
+    auto_revert = false
+    canary = 0
+  }
+
+  migrate {
+    max_parallel = 1
+    health_check = "checks"
+    min_healthy_time = "10s"
+    healthy_deadline = "5m"
+  }
+
+  group "cache" {
+    count = 1
+    restart {
+      attempts = 2
+      interval = "30m"
+      delay = "15s"
+      mode = "fail"
+    }
+
+    ephemeral_disk {
+      size = 300
+    }
+
+    task "http-echo" {
+      driver = "docker"
+
+      config {
+        image = "hashicorp/http-echo"
+
+        args = [
+          "-text",
+          "'hello world'",
+          "-listen",
+          ":8080",
+        ]
+
+        port_map {
+          http = 8080
+        }
+      }
+
+      resources {
+        cpu    = 500 # 500 MHz
+        memory = 256 # 256MB
+
+        network {
+          mbits = 10
+
+          port "http" {
+            static = 8080
+          }
+        }
+      }
+
+      service {
+        name = "http-echo"
+
+        port = "http"
+
+        check {
+          name     = "alive"
+          type     = "http"
+          interval = "10s"
+          timeout  = "2s"
+          path     = "/"
+        }
+      }
+      # The "template" stanza instructs Nomad to manage a template, such as
+      # a configuration file or script. This template can optionally pull data
+      # from Consul or Vault to populate runtime configuration data.
+      #
+      # For more information and examples on the "template" stanza, please see
+      # the online documentation at:
+      #
+      #     https://www.nomadproject.io/docs/job-specification/template.html
+      #
+      # template {
+      #   data          = "---\nkey: {{ key \"service/my-key\" }}"
+      #   destination   = "local/file.yml"
+      #   change_mode   = "signal"
+      #   change_signal = "SIGHUP"
+      # }
+
+      # The "template" stanza can also be used to create environment variables
+      # for tasks that prefer those to config files. The task will be restarted
+      # when data pulled from Consul or Vault changes.
+      #
+      # template {
+      #   data        = "KEY={{ key \"service/my-key\" }}"
+      #   destination = "local/file.env"
+      #   env         = true
+      # }
+
+      # The "vault" stanza instructs the Nomad client to acquire a token from
+      # a HashiCorp Vault server. The Nomad servers must be configured and
+      # authorized to communicate with Vault. By default, Nomad will inject
+      # The token into the job via an environment variable and make the token
+      # available to the "template" stanza. The Nomad client handles the renewal
+      # and revocation of the Vault token.
+      #
+      # For more information and examples on the "vault" stanza, please see
+      # the online documentation at:
+      #
+      #     https://www.nomadproject.io/docs/job-specification/vault.html
+      #
+      # vault {
+      #   policies      = ["cdn", "frontend"]
+      #   change_mode   = "signal"
+      #   change_signal = "SIGHUP"
+      # }
+
+      # Controls the timeout between signalling a task it will be killed
+      # and killing the task. If not set a default is used.
+      # kill_timeout = "20s"
+    }
+  }
+}


### PR DESCRIPTION
Issue #162

Complete:
- Execute a job as part of the test to make sure that nomad is able to execute jobs
- Init agent and server nomad services.
- Fixed IP where the agent is trying to connect.
```
nomad[20138]: agent: Join failed: "1 error(s) occurred:\n\n* Failed to join 127.0.0.1: dial tcp 127.0.0.1:4648: connect: connection refused", retrying in 15s
```