### PR TITLE
python.pip: drop failing module.wait

### DIFF
--- a/python/pip.sls
+++ b/python/pip.sls
@@ -30,9 +30,4 @@ pip-echo-version:
         - cmd: pip-upgrade
 
 # if we update the pip package, we need to reload modules
-pip-refresh_modules:
-  module.wait:
-    - name: saltutil.refresh_modules
-    - watch:
-        - cmd: pip
-        - cmd: pip-upgrade
+# call python.pip separately first.


### PR DESCRIPTION

Saltstack isn't great about "refreshing modules" anymore, so we drop that here.
We'll call the `python.pip` formula separately, on its own, rather than with other formula.

This should resolve #178.