### PR TITLE
docker/registry: Disable docker-registry cron job

### DIFF
--- a/docker/registry/systemd.sls
+++ b/docker/registry/systemd.sls
@@ -34,12 +34,12 @@ registry-systemd:
     - enable: True
     - watch:
         - file: registry-systemd
-  cron.present:
-    - name: salt-call --local state.sls docker.registry.systemd
-    - identifier: salt-call-apply-registry-formula
-    - user: root
-    - hour: '*'
-    - minute: '{{ cron_frequency }}'
+#  cron.present:
+#    - name: salt-call --local state.sls docker.registry.systemd
+#    - identifier: salt-call-apply-registry-formula
+#    - user: root
+#    - hour: '*'
+#    - minute: '{{ cron_frequency }}'
 
 
 registry-ufw-app-config:


### PR DESCRIPTION
Disable docker-registry cron job, the cronjob is causing overload on the machines.